### PR TITLE
Merge static and ps websites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 www/
 build/
 stage/
+.env
 .cookies
 .DS_Store
 *.tfstate

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ distclean: ## delete all build artifacts
 website-docker: distclean ## build the website docker container
 	docker build -t $(WEBSITE_DOCKER_TAG) .
 
+website-docker-no-cache: distclean ## build the website docker container
+	docker build -t $(WEBSITE_DOCKER_TAG) . --no-cache
+
 website-docker-run: ## run the website docker container
 	docker run -it --rm --name=website -p 4000:4000 $(WEBSITE_DOCKER_TAG)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Repository for ICESat-2 SlideRule documentation.
 
 The SlideRule **website** can be built and hosted locally for development purposes.
 
-### Linux Build Prerequisites
+### Linux Build Prerequisites for building on local host 
 
 1. Sphinx
 
@@ -45,7 +45,7 @@ The SlideRule **website** can be built and hosted locally for development purpos
 
 3. Docker (see [UbuntuSetup](jekyll/_howtos/UbuntuSetup.md))
 
-### MacOSx Build Prerequisites
+### MacOSx Build Prerequisites for building on local host
 
 
 1. Sphinx
@@ -95,7 +95,7 @@ The SlideRule **website** can be built and hosted locally for development purpos
 
 4. Docker (see [Install Docker on Mac](https://docs.docker.com/desktop/mac/install/) )
 
-### Build Instructions
+### Build Instructions for local host
 
 To build, in the root of the repository:
 ```bash
@@ -105,4 +105,11 @@ $ make
 To run locally (exposed as http://localhost:4000) in the root of the repository:
 ```bash
 $ make run
+```
+
+### Build Instructions for docker container
+
+To build a fully contained docker container, in the root of the repository:
+```bash
+$ make website-docker
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Repository for ICESat-2 SlideRule documentation.
 
 The SlideRule **website** can be built and hosted locally for development purposes.
 
-### Prerequisites
+### Linux Build Prerequisites
 
 1. Sphinx
 
@@ -22,7 +22,7 @@ The SlideRule **website** can be built and hosted locally for development purpos
 2. Jekyll
 
     See https://jekyllrb.com/docs/installation/ for more details.
-
+    For Linux:
     ```bash
     $ sudo apt-get install ruby-full build-essential zlib1g-dev
     $ echo 'export GEM_HOME="$HOME/gems"' >> ~/.bashrc
@@ -44,6 +44,56 @@ The SlideRule **website** can be built and hosted locally for development purpos
     ```
 
 3. Docker (see [UbuntuSetup](jekyll/_howtos/UbuntuSetup.md))
+
+### MacOSx Build Prerequisites
+
+
+1. Sphinx
+
+    See https://www.sphinx-doc.org/en/master/usage/installation.html for more details.
+
+    ```bash
+    $ pip install -U Sphinx docutils==0.16 sphinx_markdown_tables sphinx_panels sphinx_rtd_theme
+    ```
+
+    Note: docutils version 0.17.x breaks certain formatting in Sphinx (e.g. lists).  Therefore it is recommended that docutils version 0.16 be installed.
+2. chruby using [Homebrew](https://brew.sh/) (install if neccessary)
+ 
+    ```bash
+    $ brew install chruby ruby-install
+    ```
+3. Jekyll using Homebrew
+
+    See https://jekyllrb.com/docs/installation/macos/ for more details.
+
+    ```bash
+    $ brew install chruby ruby-install
+    ```
+    update .zshrc for chruby (NOTE: replace 'ruby-3.1.2' with the current version you installed):
+    ```bash
+    $ echo "source $(brew --prefix)/opt/chruby/share/chruby/chruby.sh" >> ~/.zshrc 
+    $ echo "source $(brew --prefix)/opt/chruby/share/chruby/auto.sh" >> ~/.zshrc
+    $ echo "chruby ruby-3.1.2" >> ~/.zshrc
+    ```
+
+    Then install `jekyll` 
+
+    ```bash
+    $ gem install jekyll
+    ```
+
+    Then go into the `jekyll` directory and install all depedencies.
+
+    ```bash
+    $ bundle install
+    ```
+    In the same Python environment that you installed `Sphinx` and its dependencies, you will also need to install the following dependencies.
+
+    ```bash
+    $ pip install recommonmark
+    ```
+
+4. Docker (see [Install Docker on Mac](https://docs.docker.com/desktop/mac/install/) )
 
 ### Build Instructions
 

--- a/jekyll/Gemfile.lock
+++ b/jekyll/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-linux
 

--- a/jekyll/_archive/SlideRuleFundamentals.md
+++ b/jekyll/_archive/SlideRuleFundamentals.md
@@ -12,7 +12,7 @@ category: developer
 
 SlideRule is a server-side framework implemented in C++/Lua that provides REST APIs for on demand science data processing. SlideRule can be used by researchers and other data systems for low-latency access to customized data products that are generated using processing parameters supplied at the time of the request with results returned in real-time.
 
-The development of SlideRule is led by the University of Washington in conjunction with NASA’s ICESat-2 program. The University of Washington is currently running an instantiation of SlideRule in AWS us-west-2, accessible at http://icesat2sliderule.org.  This deployment supports science investigations using ICESat-2’s ATL03, ATL06, and ATL08 datasets, and has direct access to those datasets in AWS S3 through NASA’s Cumulus program.
+The development of SlideRule is led by the University of Washington in conjunction with NASA’s ICESat-2 program. The University of Washington is currently running an instantiation of SlideRule in AWS us-west-2, accessible at [http://icesat2sliderule.org](/).  This deployment supports science investigations using ICESat-2’s ATL03, ATL06, and ATL08 datasets, and has direct access to those datasets in AWS S3 through NASA’s Cumulus program.
 
 Every deployment of SlideRule consists of three major sets of components which are supported by the SlideRule framework: the REST APIs (or web services), the data access interfaces, and the science algorithms.
 
@@ -142,5 +142,5 @@ Each EC2 instance in the cluster runs Promtail for log collection and Node Expor
 
 ## For Further Reading
 
-For further information on SlideRule, see our website at: http://icesat2sliderule.org.
+For further information on SlideRule, see our website at: [http://icesat2sliderule.org](/).
 

--- a/jekyll/_pages/GettingStarted.md
+++ b/jekyll/_pages/GettingStarted.md
@@ -13,7 +13,7 @@ category: user
 
 SlideRule is a C++/Lua framework for on-demand science data processing. It is used to build scalable systems that can process datasets and return customized results based on user provided parameters.  Its goal is to enable investigations which require processing science data in ways that were either unintended or may be inefficient given the original structure of the data.
 
-The University of Washington has partnered with the ICESat-2 program to develop and deploy an instantiation of SlideRule to AWS us-west-2 in order to support science investigations using ICESat-2's ATL03, ATL06, and ATL08 datasets.  The ICESat-2 SlideRule deployment is accessed at [icesat2sliderule.org](http://icesat2sliderule.org).
+The University of Washington has partnered with the ICESat-2 program to develop and deploy an instantiation of SlideRule to AWS us-west-2 in order to support science investigations using ICESat-2's ATL03, ATL06, and ATL08 datasets.  The ICESat-2 SlideRule deployment is accessed at [icesat2sliderule.org](/).
 
 For a top down explanation of the deployment's architecture and various components, see the [Overview](/overview/).
 

--- a/jekyll/_pages/Overview.md
+++ b/jekyll/_pages/Overview.md
@@ -13,7 +13,7 @@ category: user
 
 ___SlideRule___ is a server-side framework implemented in C++/Lua that provides REST APIs for processing science data and returning results. _SlideRule_ can be used by researchers and other data systems for low-latency access to customized data products generated using processing parameters supplied at the time of the request.
 
-_SlideRule_ runs in AWS us-west-2 and has access to the official ICESat-2 datasets hosted by the NSIDC. While its web services can be accessed by any http client (e.g. curl), a [Python client](https://github.com/ICESat2-SlideRule/sliderule-python) is provided that makes it easier to interact with _SlideRule_.  The ICESat-2 SlideRule deployment is accessed at [icesat2sliderule.org](http://icesat2sliderule.org).
+_SlideRule_ runs in AWS us-west-2 and has access to the official ICESat-2 datasets hosted by the NSIDC. While its web services can be accessed by any http client (e.g. curl), a [Python client](https://github.com/ICESat2-SlideRule/sliderule-python) is provided that makes it easier to interact with _SlideRule_.  The ICESat-2 SlideRule deployment is accessed at [icesat2sliderule.org](/).
 
 The development of _SlideRule_ is led by The University of Washington in conjunction with the  ICESat-2 program.  The initial use of SlideRule is to support science investigations using ICESat-2's ATL03, ATL06, and ATL08 datasets.
 

--- a/jekyll/_release_notes/release-v1-0-4.md
+++ b/jekyll/_release_notes/release-v1-0-4.md
@@ -21,7 +21,7 @@ Version description of the v1.0.4 release of ICESat-2 SlideRule
 
 * Created Python utility for displaying version of SlideRule running ([query_version.py](https://github.com/ICESat2-SlideRule/sliderule-python/blob/main/utils/query_version.py))
 
-* `icesat2.toregion` api now supports GeoJSON, Shapefiles, and simplifying polygons (see [documentation](http://icesat2sliderule.org/rtd/user_guide/ICESat-2.html#toregion))
+* `icesat2.toregion` api now supports GeoJSON, Shapefiles, and simplifying polygons (see [documentation](/rtd/user_guide/ICESat-2.html#toregion))
 
 * Created `sliderule-project` repository for icesat2sliderule.org; all documentation moved to this repository (includes Read the Docs).
 

--- a/jekyll/contact.md
+++ b/jekyll/contact.md
@@ -26,7 +26,7 @@ Opening an pull request is great for:
 * bug fixes you have already made to the existing code base
 * features you have already implemented and want incorporated in future releases
 
-Before opening a pull request, please read our [Contributing](http://icesat2sliderule.org/rtd/getting_started/Contributing.html) guidelines.
+Before opening a pull request, please read our [Contributing](/rtd/user_guide/Contributing.html) guidelines.
 
 For pull requests related to ***SlideRule's Python client*** or anything else related to the SlideRule user experience, please use this link to submit a PR: [sliderule-python PR](https://github.com/ICESat2-SlideRule/sliderule-python/pulls).
 

--- a/rtd/source/index.rst
+++ b/rtd/source/index.rst
@@ -59,7 +59,7 @@ Where To Begin
 Contacting Us
 -------------
 
-SlideRule is openly developed on GitHub at https://github.com/ICESat2-SlideRule.  We welcome all feedback and contributions!  For more details on the different ways to reach out to us, see our `Contact Us <http://icesat2sliderule.org/contact>`_ page.
+SlideRule is openly developed on GitHub at https://github.com/ICESat2-SlideRule.  We welcome all feedback and contributions!  For more details on the different ways to reach out to us, see our `Contact Us </contact>`_ page.
 
 
 Project Information

--- a/rtd/source/user_guide/Under-the-Hood.rst
+++ b/rtd/source/user_guide/Under-the-Hood.rst
@@ -7,7 +7,7 @@ What Is SlideRule?
 
 SlideRule is a server-side framework implemented in C++/Lua that provides REST APIs for processing science data and returning results in real-time. SlideRule can be used by researchers and other data systems for low-latency access to customized data products that are generated using processing parameters supplied at the time of the request.
 
-The development of SlideRule is led by the University of Washington in conjunction with NASA’s ICESat-2 program. The University of Washington is currently running an instantiation of SlideRule in AWS us-west-2, accessible at http://icesat2sliderule.org.  This deployment supports science investigations using ICESat-2’s ATL03, ATL06, and ATL08 datasets, and has direct access to those datasets in AWS S3 through NASA’s Cumulus program.
+The development of SlideRule is led by the University of Washington in conjunction with NASA’s ICESat-2 program. The University of Washington is currently running an instantiation of SlideRule in AWS us-west-2, accessible at [http://icesat2sliderule.org](/).  This deployment supports science investigations using ICESat-2’s ATL03, ATL06, and ATL08 datasets, and has direct access to those datasets in AWS S3 through NASA’s Cumulus program.
 
 Every deployment of SlideRule consists of three major sets of components which are supported by the SlideRule framework: the REST APIs (or web services), the data access interfaces, and the science algorithms.
 


### PR DESCRIPTION
These changes fix local references from full path to relative paths so the static website is portable to other domains (e. g. testsliderule.org)